### PR TITLE
Fix: import ExtendedKeyboardEvent from mousetrap

### DIFF
--- a/src/components/TimeGridScheduler.tsx
+++ b/src/components/TimeGridScheduler.tsx
@@ -8,6 +8,7 @@ import startOfDay from 'date-fns/start_of_day';
 import invariant from 'invariant';
 import isEqual from 'lodash/isEqual';
 import times from 'lodash/times';
+import { ExtendedKeyboardEvent } from 'mousetrap';
 import React, {
   useCallback,
   useContext,


### PR DESCRIPTION
A project I work on uses this package, but I got an error saying `TS2304: Cannot find  name 'ExtendedKeyboard'`.
Looks like it is not imported in `TimeGridScheduler.tsx` so I added the import to fix it.
